### PR TITLE
Disable tqdm progress bars when running in SLURM jobs

### DIFF
--- a/building_image_triplet_model/preprocessing/embeddings.py
+++ b/building_image_triplet_model/preprocessing/embeddings.py
@@ -1,6 +1,7 @@
 """Embedding computation for geo and backbone features."""
 
 import logging
+import os
 from typing import List, Tuple
 
 from PIL import Image
@@ -83,7 +84,10 @@ class EmbeddingComputer:
         metadata_manager = MetadataManager(self.config)
 
         for idx, row in tqdm(
-            metadata_df.iterrows(), total=len(metadata_df), desc="Generating embeddings"
+            metadata_df.iterrows(),
+            total=len(metadata_df),
+            desc="Generating embeddings",
+            disable=os.environ.get("SLURM_JOB_ID") is not None,
         ):
             img_path = metadata_manager.build_image_path(row)
             try:

--- a/building_image_triplet_model/preprocessing/hdf5_writer.py
+++ b/building_image_triplet_model/preprocessing/hdf5_writer.py
@@ -4,6 +4,7 @@ from concurrent.futures import ProcessPoolExecutor
 import gc
 from itertools import batched
 import logging
+import os
 from typing import List, Optional
 
 import h5py
@@ -91,6 +92,7 @@ class HDF5Writer:
                 batched(metadata_df.iterrows(), self.config.batch_size),
                 total=(len(metadata_df) + self.config.batch_size - 1) // self.config.batch_size,
                 desc="Processing batches",
+                disable=os.environ.get("SLURM_JOB_ID") is not None,
             )
         ):
             batch_df = pd.DataFrame([row for _, row in batch])

--- a/building_image_triplet_model/preprocessing/metadata.py
+++ b/building_image_triplet_model/preprocessing/metadata.py
@@ -1,6 +1,7 @@
 """Metadata parsing, caching, and data splitting utilities."""
 
 import logging
+import os
 from pathlib import Path
 import pickle
 from typing import Any, Dict, List, Optional
@@ -210,7 +211,9 @@ class MetadataManager:
         records: List[Dict[str, Any]] = []
 
         self.logger.info("Starting to parse .txt metadata files...")
-        for p in tqdm(txt_files, desc="Parsing .txt metadata"):
+        for p in tqdm(
+            txt_files, desc="Parsing .txt metadata", disable=os.environ.get("SLURM_JOB_ID") is not None
+        ):
             rec = self._parse_txt_file(p)
             if rec is not None:
                 records.append(rec)


### PR DESCRIPTION
Disable tqdm progress bars when SLURM_JOB_ID environment variable is set to prevent cluttering log files. Detection uses os.environ.get() to check for SLURM_JOB_ID in all three preprocessing modules.